### PR TITLE
Fix status bar text "Always" mode being hidden without mouseover

### DIFF
--- a/Modules/Artwork/StatusBars.lua
+++ b/Modules/Artwork/StatusBars.lua
@@ -564,8 +564,13 @@ function module:UpdateBarTextVisibility(containerKey)
 
 		-- Update the bar's UpdateTextVisibility function
 		bar.UpdateTextVisibility = function(self)
-			local blizzMode = self:ShouldBarTextBeDisplayed()
-			self.OverlayFrame.Text:SetShown(textMode == Enums.TextDisplayMode.Always and blizzMode)
+			if textMode == Enums.TextDisplayMode.Always then
+				self.OverlayFrame.Text:Show()
+			elseif textMode == Enums.TextDisplayMode.Never then
+				self.OverlayFrame.Text:Hide()
+			else
+				self.OverlayFrame.Text:SetShown(self:ShouldBarTextBeDisplayed())
+			end
 		end
 	end
 end
@@ -1045,8 +1050,13 @@ function module:SetupBarText(bar, StyleSetting, index)
 
 	-- Update the bar's UpdateTextVisibility function
 	bar.UpdateTextVisibility = function(self)
-		local blizzMode = self:ShouldBarTextBeDisplayed()
-		self.OverlayFrame.Text:SetShown(textMode == Enums.TextDisplayMode.Always and blizzMode)
+		if textMode == Enums.TextDisplayMode.Always then
+			self.OverlayFrame.Text:Show()
+		elseif textMode == Enums.TextDisplayMode.Never then
+			self.OverlayFrame.Text:Hide()
+		else
+			self.OverlayFrame.Text:SetShown(self:ShouldBarTextBeDisplayed())
+		end
 	end
 end
 


### PR DESCRIPTION
## Summary
- `bar.UpdateTextVisibility` (both instances, in `UpdateBarTextVisibility` and `SetupBarText`) ANDs the configured text display mode against Blizzard's own `ShouldBarTextBeDisplayed()` mouseover check.
- This means setting a status bar's text mode to **Always** only actually shows the text while the mouse happens to be hovering the bar. Whenever Blizzard's status bar mixin re-invokes `UpdateTextVisibility` (e.g. on the bar's value changing) with the mouse elsewhere, the text gets hidden again — silently overriding the Always setting.
- Same issue applies in reverse for **Never**, which currently isn't force-hidden through this path either.

## Fix
`Always` and `Never` now bypass Blizzard's mouseover check entirely and just show/hide directly. `OnMouseOver` (the implicit default/else branch) still defers to `ShouldBarTextBeDisplayed()` as before.

## Test plan
- [x] Set a status bar's text display to Always in SpartanUI options, `/reload`, confirm text stays visible with mouse away from the bar.
- [x] Set to Never, confirm text stays hidden even on hover.
- [x] Set to OnMouseOver, confirm existing hover behavior is unchanged.